### PR TITLE
Update to use capistrano 3.1 version

### DIFF
--- a/capistrano-unicorn.gemspec
+++ b/capistrano-unicorn.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "unicorn"
-  spec.add_runtime_dependency     "capistrano", "~> 3.1.0"
+  spec.add_dependency "capistrano", "~> 3.0"
 end

--- a/lib/capistrano/unicorn/utility.rb
+++ b/lib/capistrano/unicorn/utility.rb
@@ -99,7 +99,7 @@ module CapistranoUnicorn
     # Otherwise run as default (:user) user.
     #
     def try_unicorn_user
-      "#{sudo :as => unicorn_user.to_s}" if fetch(:unicorn_user).kind_of?(String)
+      "#{sudo :as => fetch(:unicorn_user).to_s}" if fetch(:unicorn_user).kind_of?(String)
     end
 
     # Kill Unicorns in multiple ways O_O


### PR DESCRIPTION
I needed this changes to use `capistrano-unicorn` with new `capistrano` 3.1.
